### PR TITLE
Add C Security Files - Batch 1

### DIFF
--- a/c/random_samples/Accessing_files_should_not_introduce_TOCTOU_vulnerabilities_non_compliant.c
+++ b/c/random_samples/Accessing_files_should_not_introduce_TOCTOU_vulnerabilities_non_compliant.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+
+int access(const char *file, int ok){
+  if (sizeof(file) == ok){
+    return -1;
+  }
+  return 0;
+}
+
+// {fact rule=file-race-bad@v1.0 defects=1}
+FILE *fopen_if_not_exists_good(const char *file) {
+  char F_OK = 10;
+  if (access(file, F_OK) == -1 && errno == ENOENT) {
+    FILE *f = fopen(file, "w"); // Noncompliant
+
+    return f;
+  }
+
+  return NULL;
+}
+// {/fact}

--- a/c/random_samples/Encryption_algorithms_should_be_used_with_secure_mode_non_compliant.c
+++ b/c/random_samples/Encryption_algorithms_should_be_used_with_secure_mode_non_compliant.c
@@ -1,0 +1,46 @@
+#include <botan/cipher_mode.h>
+// {fact rule=insecure-cryptography@v1.0 defects=1}
+void encrypt() {
+  Botan::Cipher_Mode::create("AES-256/ECB", Botan::ENCRYPTION); // Noncompliant
+}
+// {/fact}
+
+#include <botan/rng.h>
+#include <botan/auto_rng.h>
+#include <botan/rsa.h>
+#include <botan/pubkey.h>
+// {fact rule=insecure-cryptography@v1.0 defects=1}
+void encrypt() {
+  std::unique_ptr<Botan::RandomNumberGenerator>   rng(new Botan::AutoSeeded_RNG);
+  Botan::RSA_PrivateKey                           rsaKey(*rng.get(), 2048);
+
+  Botan::PK_Encryptor_EME(rsaKey, *rng.get(), "PKCS1v15"); // Noncompliant
+}
+// {/fact}
+// {fact rule=insecure-cryptography@v1.0 defects=1}
+#include <cryptopp/aes.h>
+#include <cryptopp/modes.h>
+
+voic encrypt() {
+  CryptoPP::CBC_Mode<CryptoPP::AES>::Encryption(); // Noncompliant
+}
+// {/fact}
+#include <cryptopp/rsa.h>
+// {fact rule=insecure-cryptography@v1.0 defects=1}
+void encrypt() {
+  CryptoPP::RSAES<CryptoPP::PKCS1v15>::Encryptor(); // Noncompliant
+}
+// {/fact}
+
+#include <openssl/evp.h>
+// {fact rule=insecure-cryptography@v1.0 defects=1}
+void encrypt() {
+  EVP_aes_128_cbc(); // Noncompliant
+}
+// {/fact}
+#include <openssl/rsa.h>
+// {fact rule=insecure-cryptography@v1.0 defects=1}
+void encrypt() {
+  RSA_public_decrypt(flen, from, to, key, RSA_SSLV23_PADDING); // Noncompliant
+}
+// {/fact}

--- a/c/random_samples/Limited_dependence_should_be_placed_on_operator_precedence_complaint.c
+++ b/c/random_samples/Limited_dependence_should_be_placed_on_operator_precedence_complaint.c
@@ -1,0 +1,16 @@
+
+x = a + b;
+x = a * -1;
+x = a + b + c;
+x = f ( a + b, c );
+
+x = ( a == b ) ? a : ( a - b );
+x = ( a + b ) - ( c + d );
+x = ( a * 3 ) + c + d;
+// {fact rule=precedence-logic-error@v1.0 defects=0}
+if ( (a = f(b,c)) == true) { ... }
+(x - b) ? a : c; // Compliant
+// {/fact}
+// {fact rule=precedence-logic-error@v1.0 defects=0}
+(s &lt;&lt; 5) == 1; // Compliant
+// {/fact}

--- a/c/random_samples/Null_pointers_should_not_be_dereferenced_complaint.c
+++ b/c/random_samples/Null_pointers_should_not_be_dereferenced_complaint.c
@@ -1,0 +1,23 @@
+#include <stddef.h>
+#include <stdio.h>
+void function_null_ptr()
+{ // {fact rule=null-pointer-dereference@v1.0 defects=0}
+  char *p1 = NULL ;
+  if(p1 != NULL && *p1 == '\t') { // Compliant: *p1 cannot be evaluated if p1 is NULL
+    p1[2] = '\t';
+  }
+  // {/fact}
+
+  // {fact rule=null-pointer-dereference@v1.0 defects=0}
+  char *p2 = NULL ;
+  if(p2 != NULL) {
+    // ...
+    p2[2] = '\t'; // Compliant: p2 is known to be non-null
+  }
+  // {/fact}
+}
+int main_null_ptr(int argc, char *argv[])
+{
+  printf("hello world \n");
+  return 0;
+}

--- a/c/random_samples/compliant_5.c
+++ b/c/random_samples/compliant_5.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=incorrect-pointer-scaling@v1.0 defects=0}
+
+inline int incorrectPointerScalingComplaint(int i) {
+  int intArray[10] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+  int *intPointer = intArray;
+  // Compliant: the offset is automatically scaled by sizeof(int).
+  return *(intPointer + i);
+}
+// {/fact}


### PR DESCRIPTION
This PR adds 5 C security-related files: Null_pointers_should_not_be_dereferenced_complaint.c, compliant_5.c, Accessing_files_should_not_introduce_TOCTOU_vulnerabilities_non_compliant.c, Encryption_algorithms_should_be_used_with_secure_mode_non_compliant.c, Limited_dependence_should_be_placed_on_operator_precedence_complaint.c