### PR TITLE
Add C Security Files - Batch 3

### DIFF
--- a/c/random_samples/"sizeof"_should_not_be_called_on_pointers_complaint.c
+++ b/c/random_samples/"sizeof"_should_not_be_called_on_pointers_complaint.c
@@ -1,0 +1,19 @@
+#include <stddef.h>
+#include<stdio.h>
+
+// Computing dataSize is now the responsibility of the caller
+void fun_good(int *data, int dataSize, int (*array)[10]) {
+
+  // {fact rule=incorrect-use-of-sizeof@v1.0 defects=0}
+  size_t const arraySize = sizeof(*array) / sizeof(int); // Compliant, no decay
+  // {/fact}
+  int primes[] = { 1, 2, 3, 5, 7, 13, 17, 19};
+  // {fact rule=incorrect-use-of-sizeof@v1.0 defects=0}
+  size_t const primesSize2 = sizeof primes / sizeof(int) + 1; // Compliant, type of primes is int[8]
+  // {/fact}
+}
+
+int main(){
+    printf("Hello world");
+    return 0;
+}

--- a/c/random_samples/Cryptographic_keys_should_be_robust_non_compliant.c
+++ b/c/random_samples/Cryptographic_keys_should_be_robust_non_compliant.c
@@ -1,0 +1,95 @@
+#include <botan/pubkey.h>
+#include <botan/rng.h>
+#include <botan/rsa.h>
+// {fact rule=insecure-cryptography@v1.0 defects=1}
+void encrypt() {
+    std::unique_ptr<Botan::RandomNumberGenerator>   rng(new Botan::System_RNG);
+    Botan::RSA_PrivateKey                           rsaKey(*rng, 1024); // Noncompliant
+}
+// {/fact}
+
+#include <botan/dl_group.h>
+// {fact rule=insecure-cryptography@v1.0 defects=1}
+void encrypt() {
+    Botan::DL_Group("dsa/botan/1024"); // Noncompliant
+}
+// {/fact}
+
+#include <botan/ec_group.h>
+// {fact rule=insecure-cryptography@v1.0 defects=1}
+void encrypt() {
+    Botan::EC_Group("secp160k1"); // Noncompliant
+}
+// {/fact}
+
+#include <cryptopp/rsa.h>
+#include <cryptopp/rng.h>
+// {fact rule=insecure-cryptography@v1.0 defects=1}
+void encrypt() {
+    CryptoPP::AutoSeededRandomPool  rng;
+    CryptoPP::InvertibleRSAFunction rsa_trapdoor;
+
+    rsa_trapdoor.GenerateRandomWithKeySize(rng, 1024); // Noncompliant
+}
+// {/fact}
+
+
+
+#include <cryptopp/dsa.h>
+#include <cryptopp/rng.h>
+// {fact rule=insecure-cryptography@v1.0 defects=1}
+cryptopp::autoseededrandompool rng;
+cryptopp::dsa::privatekey      dsa_private_key;
+
+dsa_private_key.GenerateRandomWithKeySize(rng, 1024); // Noncompliant
+// {/fact}
+
+#include <cryptopp/dh.h>
+#include <cryptopp/rng.h>
+// {fact rule=insecure-cryptography@v1.0 defects=1}
+cryptopp::autoseededrandompool rng;
+CryptoPP::DH                   dh;
+
+dh.AccessGroupParameters().GenerateRandomWithKeySize(rng, 1024); // Noncompliant
+// {/fact}
+
+#include <cryptopp/osrng.h>
+// {fact rule=insecure-cryptography@v1.0 defects=1}
+void ecnrypt() {
+    CryptoPP::ASN1::secp112r1(); // Noncompliant
+}
+// {/fact}
+
+#include <openssl/rsa.h>
+// {fact rule=insecure-cryptography@v1.0 defects=1}
+void encrypt() {
+    RSA* rsa_key_pair = RSA_new();
+    BIGNUM* exponent  = BSA_new();
+
+    BN_set_word(exponent, RSA_F4);
+    RSA_generate_key_ex(rsa_key_pair, 1024, exponent, NULL); // Noncompliant
+}
+// {/fact}
+
+#include <openssl/dsa.h>
+// {fact rule=insecure-cryptography@v1.0 defects=1}
+void encrypt() {
+    DSA* dsa_params = DSA_new();
+    DSA_generate_parameters_ex(dsa_params, 1024, NULL, 0, NULL, NULL, NULL); // Noncompliant
+}
+// {/fact}
+
+#include <openssl/dh.h>
+// {fact rule=insecure-cryptography@v1.0 defects=1}
+void encrypt() {
+    DH* dh_params = DH_new();
+    DH_generate_parameters_ex(dh_params, 1024, DH_GENERATOR_2, NULL); // Noncompliant
+}
+// {/fact}
+
+#include <botan/ec_group.h>
+// {fact rule=insecure-cryptography@v1.0 defects=1}
+void encrypt() {
+    EC_KEY* ec_key = EC_KEY_new_by_curve_name(NID_secp112r1); // Noncompliant
+}
+// {/fact}

--- a/c/random_samples/Variables_should_be_initialized_before_use_non_complaint.c
+++ b/c/random_samples/Variables_should_be_initialized_before_use_non_complaint.c
@@ -1,0 +1,23 @@
+// {fact rule=use-of-uninitialized-variable@v1.0 defects=1}
+int addition() {
+  int x;  // x is not initialized
+  return x + 10; // Noncompliant: x has grabage value
+}
+// {/fact}
+
+// {fact rule=use-of-uninitialized-variable@v1.0 defects=1}
+int dereference() {
+  int* p; // p is not initialized
+  return *p; // Noncompliant: p has garbage value
+}
+// {/fact}
+
+// {fact rule=use-of-uninitialized-variable@v1.0 defects=1}
+int function(int flag, int b) {
+  int a;
+  if (flag) {
+    a = b;
+  }
+  return a; // Noncompliant: "a" has not been initialized in all paths
+}
+// {/fact}

--- a/c/random_samples/compliant.c
+++ b/c/random_samples/compliant.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=incorrect-comparison@v1.0 defects=0}
+#include <stdio.h>
+
+#define X509_V_OK 1
+
+#define X509_V_ERR_CERT_HAS_EXPIRED 1
+
+void improperCertificateValidationCompliant() {
+    char* ssl;
+    // Compliant: Proper verification done
+    X509 *cert = SSL_get_peer_certificate(ssl);
+    if (cert) {
+        int result = SSL_get_verify_result(ssl);
+        if (result == X509_V_OK) {
+            //...
+        }
+    }
+}
+// {/fact}

--- a/c/random_samples/compliant_6.c
+++ b/c/random_samples/compliant_6.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=out-of-bounds-read@v1.0 defects=0}
+#include <stdio.h>
+#include <string.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+int outOfBoundsReadCompliant() {
+    int arr[5] = {1, 2, 3, 4, 5};
+    int index = 2; // Choose a valid index within the array bounds
+    // Compliant: Ensure index is within bounds before accessing the array
+    if (index >= 0 && index < 5) {
+        int value = arr[index];
+        printf("Value: %d\n", value);
+    } else {
+        printf("Invalid index\n");
+    }
+    return 0;
+}
+// {/fact}


### PR DESCRIPTION
This PR adds 5 C security-related files: sizeof_should_not_be_called_on_pointers_complaint.c, Variables_should_be_initialized_before_use_non_complaint.c, compliant.c, compliant_6.c, Cryptographic_keys_should_be_robust_non_compliant.c