### PR TITLE
Add C Security Files - Batch 4

### DIFF
--- a/c/random_samples/Function_exit_paths_should_have_appropriate_return_values_non_complaint.c
+++ b/c/random_samples/Function_exit_paths_should_have_appropriate_return_values_non_complaint.c
@@ -1,0 +1,9 @@
+// {fact rule=unexpected-return-value@v1.0 defects=1}
+int my_func(int a) {
+  if (a > 100) {
+    return; // Noncompliant
+  }
+
+  // Noncompliant
+}
+// {/fact}

--- a/c/random_samples/Using_strncpy_or_wcsncpy_is_security-sensitive_non_complaint.c
+++ b/c/random_samples/Using_strncpy_or_wcsncpy_is_security-sensitive_non_complaint.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int doSomethingWith_strncpy_or_wcsncpy_bad(char *dest){
+    //something
+    return 1;
+}
+
+// {fact rule=classic-buffer-overflow@v1.0 defects=1}
+int f_strncpy_or_wcsncpy_bad(char *src) {
+  char dest[256];
+  strncpy(dest, src, sizeof(dest)); // Sensitive: might silently truncate
+  return doSomethingWith_strncpy_or_wcsncpy_bad(dest);
+}
+// {/fact}
+
+

--- a/c/random_samples/compliant_11.c
+++ b/c/random_samples/compliant_11.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=os-command-injection@v1.0 defects=0}
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+
+int osCommandInjectionCompliant(int argc, char** argv) {
+    char cat[] = "cat ";
+    char *command;
+    size_t commandLength;
+
+    commandLength = strlen(cat) + 1;
+    command = (char *) malloc(commandLength);
+    strncpy(command, cat, commandLength);
+
+    // Compliant: The (hardcoded) cat command will be executed
+    system(command);
+    return (0);
+}
+// {/fact}

--- a/c/random_samples/compliant_2.c
+++ b/c/random_samples/compliant_2.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-use-of-chroot@v1.0 defects=0}
+#include <stdio.h>
+void insecureUseofChrootCompliant(){
+
+    const char* root_dir = "/jail/";
+
+    if(chdir(root_dir) == -1) {
+      exit(-1);
+    }
+    // Compliant: the current dir is changed to the jail and the results of both functions are checked
+    if(chroot(root_dir) == -1) {  
+      exit(-1);
+    }
+
+}
+// {/fact}

--- a/c/random_samples/compliant_8.c
+++ b/c/random_samples/compliant_8.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=out-of-bounds-write@v1.0 defects=0}
+#include <stdio.h>
+
+void outOfBoundsWriteCompliant(){
+
+  // Compliant: Ensuring correct loop bounds
+  int arr[3] = {1, 2, 3};
+  for (int i = 0; i < 3; ++i) {
+    arr[i] = i * 2; // Accessing indices within array bounds 
+  }
+}
+// {/fact}


### PR DESCRIPTION
This PR adds 5 C security-related files: Using_strncpy_or_wcsncpy_is_security-sensitive_non_complaint.c, compliant_2.c, compliant_8.c, compliant_11.c, Function_exit_paths_should_have_appropriate_return_values_non_complaint.c