### PR TITLE
Add C Security Files - Batch 5

### DIFF
--- a/c/random_samples/Boolean_expressions_should_not_be_gratuitous_non_compliant.c
+++ b/c/random_samples/Boolean_expressions_should_not_be_gratuitous_non_compliant.c
@@ -1,0 +1,34 @@
+#include <stdbool.h>
+#include<stdio.h>
+
+void doSomething(){
+    //do something
+}
+
+
+void func(){
+    bool a = true;
+    char *b = "b";
+    char *c = "c";
+    a = true;
+    // {fact rule=expression-always-true@v1.0 defects=1}
+    if (a) { // Noncompliant
+      doSomething();
+    }
+    // {/fact}
+    // {fact rule=expression-always-true@v1.0 defects=1}
+    if (b && a) { // Noncompliant; "a" is always "true"
+      doSomething();
+    }
+    // {/fact}
+    // {fact rule=expression-always-true@v1.0 defects=1}
+    if (c || !a) { // Noncompliant; "!a" is always "false"
+      doSomething();
+    }
+    // {/fact}
+}
+
+int main() {
+    printf("Hello World");
+    return 0;
+}

--- a/c/random_samples/Freed_memory_should_not_be_used_non_complaint.c
+++ b/c/random_samples/Freed_memory_should_not_be_used_non_complaint.c
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+
+void freed_memory_should_not_be_used_non_complaint() // any function 
+{
+// {fact rule=use-after-free@v1.0 defects=1}
+char *cp = (char*)malloc(sizeof(char)*10); // memory is allocated
+// all bytes in cp can be used here
+free(cp); // memory is released
+cp[9] = 0; // Noncompliant: memory is used after it was released
+// {/fact}
+
+// {fact rule=use-after-free@v1.0 defects=1}
+int *intArray = malloc(sizeof(int) *20); // memory is allocated
+// elements of intArray can be written or read here
+intArray=NULL; // memory is released
+intArray[3] = 10; // Noncompliant: memory is used after it was released
+// {/fact}
+
+}

--- a/c/random_samples/Using_"strcpy"_or_"wcscpy"_is_security-sensitive_complaint.c
+++ b/c/random_samples/Using_"strcpy"_or_"wcscpy"_is_security-sensitive_complaint.c
@@ -1,0 +1,17 @@
+#include <stdlib.h>
+#include <string.h>
+
+int doSomethingWithgood(char *dest){
+    //something
+    return 1;
+}
+
+// {fact rule=classic-buffer-overflow@v1.0 defects=0}
+int f_good(char *src) {
+  char *dest = malloc(strlen(src) + 1); // For the final 0
+  strcpy(dest, src); // Compliant: we made sure the buffer is large enough
+  int r= doSomethingWithgood(dest);
+  free(dest);
+  return r;
+}
+// {/fact}

--- a/c/random_samples/non-compliant_3.c
+++ b/c/random_samples/non-compliant_3.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-use-memset@v1.0 defects=1}
+#include <string.h>
+#include <stdlib.h>
+
+void insecureUseMemsetNonCompliant() {
+    char *buffer = malloc(1024);
+    // Noncompliant: Use of insecure function.
+    memset(buffer, 0, 512);
+    free(buffer);
+}
+// {/fact}

--- a/c/random_samples/pthread_mutex_t_should_not_be_locked_compliant.c
+++ b/c/random_samples/pthread_mutex_t_should_not_be_locked_compliant.c
@@ -1,0 +1,18 @@
+#include <pthread.h>
+#include<stdio.h>
+
+pthread_mutex_t m1 = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t m2 = PTHREAD_MUTEX_INITIALIZER;
+// {fact rule=thread-safety-violation@v1.0 defects=0}
+void locks_good() {
+  pthread_mutex_lock(&m1);
+  pthread_mutex_lock(&m2); // Compliant: we acquired both 'm1' and 'm2' for the first time.
+}
+// {/fact}
+
+// {fact rule=thread-safety-violation@v1.0 defects=0}
+void unlocks_good() {
+  pthread_mutex_unlock(&m2);
+  pthread_mutex_unlock(&m1); // Compliant: we released both 'm1' and 'm2' for the first time.
+}
+// {/fact}


### PR DESCRIPTION
This PR adds 5 C security-related files: pthread_mutex_t_should_not_be_locked_compliant.c, non-compliant_3.c, Using_strcpy_or_wcscpy_is_security-sensitive_complaint.c, Freed_memory_should_not_be_used_non_complaint.c, Boolean_expressions_should_not_be_gratuitous_non_compliant.c